### PR TITLE
feat: soften UI color palette

### DIFF
--- a/collaboration-dashboard/_components/layout/BottomNav.tsx
+++ b/collaboration-dashboard/_components/layout/BottomNav.tsx
@@ -14,9 +14,9 @@ const items = [
 export function BottomNav() {
   const path = usePathname();
   return (
-    <nav className="fixed bottom-0 inset-x-0 bg-white border-t flex justify-around py-2">
+    <nav className="fixed bottom-0 inset-x-0 bg-white/90 backdrop-blur border-t border-slate-200 flex justify-around py-2">
       {items.map((it) => (
-        <Link key={it.href} href={it.href} className={`text-sm ${path.startsWith(it.href) ? 'text-sky-700' : 'text-slate-600'}`}>
+        <Link key={it.href} href={it.href} className={`text-sm ${path.startsWith(it.href) ? 'text-primary' : 'text-slate-600'}`}>
           {it.label}
         </Link>
       ))}

--- a/collaboration-dashboard/_components/ui/Card.tsx
+++ b/collaboration-dashboard/_components/ui/Card.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
 
 export function Card({ children }: { children: ReactNode }) {
-  return <div className="bg-white border rounded-xl p-4 shadow">{children}</div>;
+  return <div className="bg-white border rounded-xl p-4 shadow-sm">{children}</div>;
 }

--- a/collaboration-dashboard/_components/ui/Chip.tsx
+++ b/collaboration-dashboard/_components/ui/Chip.tsx
@@ -7,9 +7,9 @@ export function Chip({ children, onClick, active }: Props) {
     <button
       type="button"
       onClick={onClick}
-      className={`px-2 py-1 text-xs rounded-full border ${active ? 'bg-sky-700 text-white border-sky-700' : 'bg-slate-100 text-slate-700 border-slate-300'}`}
-    >
-      {children}
-    </button>
+        className={`px-2 py-1 text-xs rounded-full border ${active ? 'bg-primary text-white border-primary' : 'bg-slate-100 text-slate-700 border-slate-300'}`}
+      >
+        {children}
+      </button>
   );
 }

--- a/collaboration-dashboard/_components/ui/PillTabs.tsx
+++ b/collaboration-dashboard/_components/ui/PillTabs.tsx
@@ -6,11 +6,11 @@ export function PillTabs({ items, value, onChange }: Props) {
       {items.map((it) => (
         <button
           key={it}
-          className={`px-3 py-1 rounded-full border text-sm ${value === it ? 'bg-sky-700 text-white border-sky-700' : 'bg-white border-slate-300'}`}
-          onClick={() => onChange(it)}
-        >
-          {it}
-        </button>
+            className={`px-3 py-1 rounded-full border text-sm ${value === it ? 'bg-primary text-white border-primary' : 'bg-white border-slate-300'}`}
+            onClick={() => onChange(it)}
+          >
+            {it}
+          </button>
       ))}
     </div>
   );

--- a/collaboration-dashboard/app/globals.css
+++ b/collaboration-dashboard/app/globals.css
@@ -1,7 +1,15 @@
 @import "tailwindcss";
 
+@theme {
+  --color-primary: #7dd3fc;
+}
+
+@layer base {
+  body { @apply bg-slate-50 text-slate-800 font-sans; }
+}
+
 @layer components {
-  .btn { @apply h-10 px-3 rounded-xl border text-sm; }
-  .btn-primary { @apply h-10 px-3 rounded-xl border text-sm bg-sky-700 text-white border-sky-700; }
+  .btn { @apply h-10 px-3 rounded-xl border text-sm bg-white text-slate-700 border-slate-300; }
+  .btn-primary { @apply h-10 px-3 rounded-xl border text-sm bg-primary text-white border-primary; }
   .btn-ghost { @apply h-10 px-3 rounded-xl border text-sm bg-transparent text-slate-600 border-slate-300; }
 }

--- a/collaboration-dashboard/app/news/page.tsx
+++ b/collaboration-dashboard/app/news/page.tsx
@@ -43,11 +43,11 @@ export default function NewsPage() {
             <p>{detail.summary}</p>
             {detail.audience && <p>対象: {detail.audience}</p>}
             {detail.apply && <p>申込: {detail.apply}</p>}
-            {detail.url && (
-              <a href={detail.url} className="text-sky-700 underline">
-                リンク
-              </a>
-            )}
+              {detail.url && (
+                <a href={detail.url} className="text-primary underline">
+                  リンク
+                </a>
+              )}
             <div className="mt-4 border-t pt-4">
               <h3 className="font-semibold mb-2">AIとチャット</h3>
               <div className="space-y-1 max-h-32 overflow-y-auto text-sm p-2 border rounded bg-slate-50">

--- a/collaboration-dashboard/tailwind.config.ts
+++ b/collaboration-dashboard/tailwind.config.ts
@@ -5,7 +5,7 @@ export default {
   theme: {
     extend: {
       colors: {
-        primary: '#0369a1'
+        primary: '#7dd3fc'
       }
     }
   },


### PR DESCRIPTION
## Summary
- add pastel `primary` theme color and apply across buttons, tabs, and chips
- use light background and font base for a gentler look
- refine bottom nav and card shadow for a softer presentation

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68bbc2b486508331acbe1cd87db71719