### PR TITLE
Move issue creation form to dialog

### DIFF
--- a/collaboration-dashboard/__tests__/issues.test.tsx
+++ b/collaboration-dashboard/__tests__/issues.test.tsx
@@ -9,7 +9,8 @@ vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }));
 test('creating an issue adds to list', () => {
   useAppStore.setState(initialState);
   render(<IssuesPage />);
+  fireEvent.click(screen.getByText('新規課題作成'));
   fireEvent.change(screen.getByPlaceholderText('タイトル'), { target: { value: '新しい課題' } });
-  fireEvent.click(screen.getByText('課題カード作成'));
+  fireEvent.click(screen.getAllByText('課題カード作成')[1]);
   expect(screen.getByText('新しい課題')).toBeInTheDocument();
 });

--- a/collaboration-dashboard/_mock/communities.ts
+++ b/collaboration-dashboard/_mock/communities.ts
@@ -20,6 +20,7 @@ export const issues: Issue[] = [
     title: 'ゴミのポイ捨て',
     target: '駅前',
     area: '市内',
+    detail: '',
     evidence: '写真',
     kpis: ['清掃回数'],
     impact: 3,

--- a/collaboration-dashboard/_types/index.ts
+++ b/collaboration-dashboard/_types/index.ts
@@ -17,6 +17,7 @@ export type Issue = {
   title: string;
   target?: string;
   area?: string;
+  detail?: string;
   evidence?: string;
   kpis: string[];
   impact: number;

--- a/collaboration-dashboard/app/globals.css
+++ b/collaboration-dashboard/app/globals.css
@@ -12,4 +12,17 @@
   .btn { @apply h-10 px-3 rounded-xl border text-sm bg-white text-slate-700 border-slate-300; }
   .btn-primary { @apply h-10 px-3 rounded-xl border text-sm bg-primary text-white border-primary; }
   .btn-ghost { @apply h-10 px-3 rounded-xl border text-sm bg-transparent text-slate-600 border-slate-300; }
+  .chip-btn {
+    padding: 6px 10px;
+    border-radius: 999px;
+    border: 1px solid #cbd5e1;
+    background: #f8fafc;
+    color: #475569;
+    font-size: 12px;
+  }
+  .chip-btn.active {
+    border-color: #0891b2;
+    background: #0891b2;
+    color: #ffffff;
+  }
 }

--- a/collaboration-dashboard/app/issues/page.tsx
+++ b/collaboration-dashboard/app/issues/page.tsx
@@ -11,8 +11,9 @@ export default function IssuesPage() {
     title: '',
     target: '',
     area: '',
+    detail: '',
     evidence: '',
-    kpi: '',
+    kpis: [] as string[],
     impact: 1,
     feasible: 1
   });
@@ -23,13 +24,14 @@ export default function IssuesPage() {
       title: form.title,
       target: form.target,
       area: form.area,
+      detail: form.detail,
       evidence: form.evidence,
-      kpis: form.kpi ? [form.kpi] : [],
+      kpis: form.kpis,
       impact: form.impact,
       feasible: form.feasible,
       communityId: null
     });
-    setForm({ title: '', target: '', area: '', evidence: '', kpi: '', impact: 1, feasible: 1 });
+    setForm({ title: '', target: '', area: '', detail: '', evidence: '', kpis: [], impact: 1, feasible: 1 });
     setOpen(false);
   };
   return (
@@ -59,37 +61,40 @@ export default function IssuesPage() {
             placeholder="エリア"
             className="w-full border rounded p-2"
           />
+          <textarea
+            value={form.detail}
+            onChange={(e) => setForm({ ...form, detail: e.target.value })}
+            placeholder="課題の詳細"
+            rows={2}
+            className="w-full border rounded p-2"
+          />
           <input
             value={form.evidence}
             onChange={(e) => setForm({ ...form, evidence: e.target.value })}
             placeholder="証拠"
             className="w-full border rounded p-2"
           />
-          <input
-            value={form.kpi}
-            onChange={(e) => setForm({ ...form, kpi: e.target.value })}
-            placeholder="KPI"
-            className="w-full border rounded p-2"
-          />
-          <div className="flex gap-2">
-            <input
-              type="number"
-              min={1}
-              max={5}
-              value={form.impact}
-              onChange={(e) => setForm({ ...form, impact: Number(e.target.value) })}
-              className="border rounded p-2 w-full"
-              placeholder="Impact"
-            />
-            <input
-              type="number"
-              min={1}
-              max={5}
-              value={form.feasible}
-              onChange={(e) => setForm({ ...form, feasible: Number(e.target.value) })}
-              className="border rounded p-2 w-full"
-              placeholder="Feasible"
-            />
+          <div>
+            <div className="font-semibold">KPI</div>
+            <div className="flex gap-2 mt-1">
+              {['平均所要時間(分)', '満足度(点)'].map((k) => (
+                <button
+                  key={k}
+                  type="button"
+                  className={`chip-btn ${form.kpis.includes(k) ? 'active' : ''}`}
+                  onClick={() =>
+                    setForm((prev) => ({
+                      ...prev,
+                      kpis: prev.kpis.includes(k)
+                        ? prev.kpis.filter((x) => x !== k)
+                        : [...prev.kpis, k]
+                    }))
+                  }
+                >
+                  {k}
+                </button>
+              ))}
+            </div>
           </div>
           <button className="btn btn-primary w-full" onClick={handleSubmit}>
             課題カード作成

--- a/collaboration-dashboard/app/issues/page.tsx
+++ b/collaboration-dashboard/app/issues/page.tsx
@@ -2,9 +2,11 @@
 import { useState } from 'react';
 import { IssueList } from '@/_components/issue/IssueList';
 import { useAppStore } from '@/_store/useAppStore';
+import { Dialog } from '@/_components/ui/Dialog';
 
 export default function IssuesPage() {
   const saveIssue = useAppStore((s) => s.saveIssue);
+  const [open, setOpen] = useState(false);
   const [form, setForm] = useState({
     title: '',
     target: '',
@@ -28,66 +30,72 @@ export default function IssuesPage() {
       communityId: null
     });
     setForm({ title: '', target: '', area: '', evidence: '', kpi: '', impact: 1, feasible: 1 });
+    setOpen(false);
   };
   return (
     <main className="p-4">
       <h1 className="text-lg font-semibold mb-4">課題</h1>
       <IssueList />
-      <div className="mt-4 space-y-2">
-        <input
-          value={form.title}
-          onChange={(e) => setForm({ ...form, title: e.target.value })}
-          placeholder="タイトル"
-          className="w-full border rounded p-2"
-        />
-        <input
-          value={form.target}
-          onChange={(e) => setForm({ ...form, target: e.target.value })}
-          placeholder="ターゲット"
-          className="w-full border rounded p-2"
-        />
-        <input
-          value={form.area}
-          onChange={(e) => setForm({ ...form, area: e.target.value })}
-          placeholder="エリア"
-          className="w-full border rounded p-2"
-        />
-        <input
-          value={form.evidence}
-          onChange={(e) => setForm({ ...form, evidence: e.target.value })}
-          placeholder="証拠"
-          className="w-full border rounded p-2"
-        />
-        <input
-          value={form.kpi}
-          onChange={(e) => setForm({ ...form, kpi: e.target.value })}
-          placeholder="KPI"
-          className="w-full border rounded p-2"
-        />
-        <div className="flex gap-2">
+      <button className="btn btn-primary mt-4" onClick={() => setOpen(true)}>
+        新規課題作成
+      </button>
+      <Dialog open={open} onClose={() => setOpen(false)} title="課題カード作成">
+        <div className="space-y-2">
           <input
-            type="number"
-            min={1}
-            max={5}
-            value={form.impact}
-            onChange={(e) => setForm({ ...form, impact: Number(e.target.value) })}
-            className="border rounded p-2 w-full"
-            placeholder="Impact"
+            value={form.title}
+            onChange={(e) => setForm({ ...form, title: e.target.value })}
+            placeholder="タイトル"
+            className="w-full border rounded p-2"
           />
           <input
-            type="number"
-            min={1}
-            max={5}
-            value={form.feasible}
-            onChange={(e) => setForm({ ...form, feasible: Number(e.target.value) })}
-            className="border rounded p-2 w-full"
-            placeholder="Feasible"
+            value={form.target}
+            onChange={(e) => setForm({ ...form, target: e.target.value })}
+            placeholder="ターゲット"
+            className="w-full border rounded p-2"
           />
+          <input
+            value={form.area}
+            onChange={(e) => setForm({ ...form, area: e.target.value })}
+            placeholder="エリア"
+            className="w-full border rounded p-2"
+          />
+          <input
+            value={form.evidence}
+            onChange={(e) => setForm({ ...form, evidence: e.target.value })}
+            placeholder="証拠"
+            className="w-full border rounded p-2"
+          />
+          <input
+            value={form.kpi}
+            onChange={(e) => setForm({ ...form, kpi: e.target.value })}
+            placeholder="KPI"
+            className="w-full border rounded p-2"
+          />
+          <div className="flex gap-2">
+            <input
+              type="number"
+              min={1}
+              max={5}
+              value={form.impact}
+              onChange={(e) => setForm({ ...form, impact: Number(e.target.value) })}
+              className="border rounded p-2 w-full"
+              placeholder="Impact"
+            />
+            <input
+              type="number"
+              min={1}
+              max={5}
+              value={form.feasible}
+              onChange={(e) => setForm({ ...form, feasible: Number(e.target.value) })}
+              className="border rounded p-2 w-full"
+              placeholder="Feasible"
+            />
+          </div>
+          <button className="btn btn-primary w-full" onClick={handleSubmit}>
+            課題カード作成
+          </button>
         </div>
-        <button className="btn btn-primary w-full" onClick={handleSubmit}>
-          課題カード作成
-        </button>
-      </div>
+      </Dialog>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- show a "新規課題作成" button on the Issues page
- move the issue creation fields into a modal dialog triggered by the button
- adjust tests to open the dialog before submitting a new issue

## Testing
- `pnpm lint`
- `pnpm vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68bbded432388331b37009d935ed9612