### PR TITLE
Reset thread when switching communities

### DIFF
--- a/collaboration-dashboard/__tests__/store.test.ts
+++ b/collaboration-dashboard/__tests__/store.test.ts
@@ -27,4 +27,12 @@ describe('store actions', () => {
     });
     expect(useAppStore.getState().issues.length).toBe(count + 1);
   });
+
+  test('selectCommunity resets selectedThreadId', () => {
+    const { openThread, selectCommunity, communities } = useAppStore.getState();
+    openThread('t1');
+    expect(useAppStore.getState().selectedThreadId).toBe('t1');
+    selectCommunity(communities[1]);
+    expect(useAppStore.getState().selectedThreadId).toBeNull();
+  });
 });

--- a/collaboration-dashboard/_store/useAppStore.ts
+++ b/collaboration-dashboard/_store/useAppStore.ts
@@ -22,7 +22,7 @@ type AppState = {
 
 export const useAppStore = create<AppState>((set) => ({
   ...initialState,
-  selectCommunity: (c) => set({ selectedCommunity: c }),
+  selectCommunity: (c) => set({ selectedCommunity: c, selectedThreadId: null }),
   openThread: (id) => set({ selectedThreadId: id }),
   addThread: (communityId, title, firstMessage) => {
     const id = `t${Date.now()}`;


### PR DESCRIPTION
## Summary
- clear selected thread when a new community is chosen
- cover thread reset with unit tests to prevent stale message views

## Testing
- `pnpm run test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68be19ba486c8331b8871f4e53c81b52