### PR TITLE
feat: show join link when no communities

### DIFF
--- a/collaboration-dashboard/__tests__/MyCommunityList.test.tsx
+++ b/collaboration-dashboard/__tests__/MyCommunityList.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import { MyCommunityList } from '../_components/community/MyCommunityList';
+import { useAppStore } from '../_store/useAppStore';
+import { initialState } from '../_mock/initialState';
+import { vi } from 'vitest';
+
+import '@testing-library/jest-dom';
+
+test('shows join link when no communities', () => {
+  useAppStore.setState({ ...initialState, myCommunities: [] });
+  render(<MyCommunityList onSelect={vi.fn()} />);
+  expect(screen.getByText('参加中のコミュニティはありません')).toBeInTheDocument();
+  const link = screen.getByRole('link', { name: 'コミュニティに参加する' });
+  expect(link).toHaveAttribute('href', '/community/join');
+});

--- a/collaboration-dashboard/_components/community/MyCommunityList.tsx
+++ b/collaboration-dashboard/_components/community/MyCommunityList.tsx
@@ -2,6 +2,7 @@
 import { useAppStore } from '@/_store/useAppStore';
 import { Card } from '@/_components/ui/Card';
 import { Community } from '@/_types';
+import Link from 'next/link';
 
 export { Card } from '@/_components/ui/Card';
 
@@ -9,6 +10,16 @@ export function MyCommunityList({ onSelect }: { onSelect: (community: Community)
   const communities = useAppStore((s) => s.communities);
   const my = useAppStore((s) => s.myCommunities);
   const list = communities.filter((c) => my.includes(c.id));
+  if (list.length === 0) {
+    return (
+      <div className="mt-4 text-center space-y-2">
+        <div>参加中のコミュニティはありません</div>
+        <Link href="/community/join" className="text-primary underline">
+          コミュニティに参加する
+        </Link>
+      </div>
+    );
+  }
   return (
     <div className="space-y-2 mt-4">
       {list.map((c) => (


### PR DESCRIPTION
## Summary
- handle empty MyCommunityList by prompting to join a community
- add test verifying join link renders when the user is not part of any community

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68be1bbb467c8331ae566d49d6a95510